### PR TITLE
Addresses an issue with paths, allowing env files from other locations

### DIFF
--- a/Model/App.php
+++ b/Model/App.php
@@ -19,7 +19,7 @@ class App extends \FishPig\WordPress\Model\App
 
     /**
      * Dependency Injection
-     * 
+     *
      * @param \FishPig\WordPress\Model\Config                 $config
      * @param \FishPig\WordPress\Model\App\ResourceConnection $resourceConnection
      * @param \FishPig\WordPress\Model\App\Url                $urlBuilder
@@ -46,6 +46,7 @@ class App extends \FishPig\WordPress\Model\App
         if (is_null($this->_isBedrock)) {
             $this->_isBedrock = (bool) $this->getConfig()->getStoreConfigValue('wordpress/setup/bedrock_enabled');
         }
+
         return $this->_isBedrock;
     }
 
@@ -56,6 +57,12 @@ class App extends \FishPig\WordPress\Model\App
      */
     public function getPath()
     {
+        $env = $this->getConfig()->getStoreConfigValue('wordpress/setup/bedrock_env');
+
+        if (! empty($env)) {
+            return realpath('../');
+        }
+
         if (!is_null($this->path)) {
             return $this->path;
         }
@@ -63,7 +70,24 @@ class App extends \FishPig\WordPress\Model\App
         if ($this->getBedrockEnabled()) {
             return $this->getConfig()->getStoreConfigValue('wordpress/setup/bedrock_path');
         }
+
         return parent::getPath();
+    }
+
+    /**
+     * Get the filename of the env file
+     *
+     * @return string
+     */
+    public function getEnvFile()
+    {
+        $env = $this->getConfig()->getStoreConfigValue('wordpress/setup/bedrock_env');
+
+        if (! empty($env)) {
+            return $env;
+        }
+
+        return '.env';
     }
 
     /**
@@ -76,8 +100,9 @@ class App extends \FishPig\WordPress\Model\App
     {
         if (is_null($this->wpconfig) && $this->getBedrockEnabled()) {
             $env = new \Dotenv\Dotenv(
-                trim($this->getPath())
+                $this->getPath(), $this->getEnvFile()
             );
+
             $env = $env->load();
 
             if (! empty($_ENV)) {
@@ -117,12 +142,12 @@ class App extends \FishPig\WordPress\Model\App
                     sprintf('Your home URL (%s) is invalid as it does not start with the Magento base URL (%s).', $this->wpUrlBuilder->getHomeUrl(), $magentoUrl)
                 );
             }
-            
+
             if ($this->wpUrlBuilder->getHomeUrl() === $magentoUrl) {
                 IntegrationException::throwException('Your WordPress Home URL matches your Magento URL. Try changing your Home URL to something like ' . $magentoUrl . '/blog');
             }
         }
-        
+
         return $this;
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -18,7 +18,14 @@
                 </field>
                 <field id="bedrock_path" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Bedrock Path</label>
-                    <comment>Enter the absolute path to your Bedrock installation.</comment>
+                    <comment>Enter the relative path to your Bedrock installation from the public folder.</comment>
+                    <depends>
+                        <field id="*/*/bedrock_enabled">1</field>
+                    </depends>
+                </field>
+                <field id="bedrock_env" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" default="ksdjk">
+                    <label>Bedrock Env File Path</label>
+                    <comment>(Optional) Enter the absolute path to your .env from the project root if you're using a custom file name.</comment>
                     <depends>
                         <field id="*/*/bedrock_enabled">1</field>
                     </depends>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,7 +23,7 @@
                         <field id="*/*/bedrock_enabled">1</field>
                     </depends>
                 </field>
-                <field id="bedrock_env" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1" default="ksdjk">
+                <field id="bedrock_env" translate="label comment" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Bedrock Env File Path</label>
                     <comment>(Optional) Enter the absolute path to your .env from the project root if you're using a custom file name.</comment>
                     <depends>


### PR DESCRIPTION
Hi,

We hit a bit of trouble recently with having multiple env files for things like phpunit e.g `.env.test` as the "Path" is relative (not absolute as the label says) it forces you to use the file name and location of the .env file as `.env` where as the Dotenv library accepts a custom filename for this very reason, however this package doesnt allow you to use that functionality.

This PR adds a new field, allowing you to define your .env filename and location - falling back to the original .env if left empty.

![configuration___settings___stores___magento_admin](https://user-images.githubusercontent.com/1094740/35046748-ca968a68-fb8f-11e7-842f-4df0c88d46f0.jpg)
