### PR TITLE
Fixes path issue that I created

### DIFF
--- a/Model/App.php
+++ b/Model/App.php
@@ -57,12 +57,6 @@ class App extends \FishPig\WordPress\Model\App
      */
     public function getPath()
     {
-        $env = $this->getConfig()->getStoreConfigValue('wordpress/setup/bedrock_env');
-
-        if (! empty($env)) {
-            return realpath('../');
-        }
-
         if (!is_null($this->path)) {
             return $this->path;
         }
@@ -99,8 +93,11 @@ class App extends \FishPig\WordPress\Model\App
     public function getWpConfigValue($key = null)
     {
         if (is_null($this->wpconfig) && $this->getBedrockEnabled()) {
+            $fullEnvPath = realpath(rtrim($this->getPath(), '/') . '/' . ltrim($this->getEnvFile()));
+            $fullEnvPathInfo = pathinfo($fullEnvPath);
+
             $env = new \Dotenv\Dotenv(
-                $this->getPath(), $this->getEnvFile()
+                $fullEnvPathInfo['dirname'], $fullEnvPathInfo['basename']
             );
 
             $env = $env->load();


### PR DESCRIPTION
Previously a PR I submitted allows you to use DotEnvs second param.

However it relies on the 1st param being where the env is stored - however as the env file might be stored in a different place to the wordpress installation.

e.g

wordpress install = /public_html/wordpress
env location = /.env

it would make some plugins not work that call "getPath()"

This addresses that issue!
